### PR TITLE
Update requirements.txt based on install with sarif

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,10 @@ attrs==25.3.0 \
     --hash=sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b
     # via
     #   cattrs
+    #   jschema-to-python
     #   lsprotocol
-bandit==1.8.3 \
+    #   sarif-om
+bandit[sarif]==1.8.3 \
     --hash=sha256:28f04dc0d258e1dd0f99dee8eefa13d1cb5e3fde1a5ab0c523971f97b289bcd8 \
     --hash=sha256:f5847beb654d309422985c36644649924e0ea4425c76dec2e89110b87506193a
     # via -r ./requirements.in
@@ -20,6 +22,14 @@ cattrs==24.1.2 \
     # via
     #   lsprotocol
     #   pygls
+jschema-to-python==1.2.3 \
+    --hash=sha256:76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91 \
+    --hash=sha256:8a703ca7604d42d74b2815eecf99a33359a8dccbb80806cce386d5e2dd992b05
+    # via bandit
+jsonpickle==4.0.2 \
+    --hash=sha256:3e650b9853adcdab9d9d62a88412b6d36e9a59ba423b01cacf0cd4ee80733aca \
+    --hash=sha256:cd3c90d32a68dcaa7f0e4b918bda7d4bb61f3c03b182d82dae2caf9ded0ab6b3
+    # via jschema-to-python
 lsprotocol==2023.0.1 \
     --hash=sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2 \
     --hash=sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d
@@ -39,7 +49,10 @@ packaging==24.2 \
 pbr==6.1.1 \
     --hash=sha256:38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76 \
     --hash=sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b
-    # via stevedore
+    # via
+    #   jschema-to-python
+    #   sarif-om
+    #   stevedore
 pygls==1.3.1 \
     --hash=sha256:140edceefa0da0e9b3c533547c892a42a7d2fd9217ae848c330c53d266a55018 \
     --hash=sha256:6e00f11efc56321bdeb6eac04f6d86131f654c7d49124344a9ebb968da3dd91e
@@ -106,6 +119,10 @@ pyyaml==6.0.2 \
 rich==13.9.4 \
     --hash=sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098 \
     --hash=sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90
+    # via bandit
+sarif-om==1.0.4 \
+    --hash=sha256:539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911 \
+    --hash=sha256:cd5f416b3083e00d402a92e449a7ff67af46f11241073eea0461802a3b5aef98
     # via bandit
 stevedore==5.4.1 \
     --hash=sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b \


### PR DESCRIPTION
The requirements.txt gets updated with an install of requirements.in. Last commit changed to include the sarif extra on Bandit. So it needed a rerun of the install.