### PR TITLE
Fix the code and code description part of diagnostic

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -114,6 +114,7 @@ def _parse_output(content: str) -> list[lsp.Diagnostic]:
 
     for result in results:
         location = result["locations"][0]["physicalLocation"]
+        rule = run["tool"]["driver"]["rules"][result["ruleIndex"]]
 
         start = lsp.Position(
             line=location["region"]["startLine"] - line_offset,
@@ -133,8 +134,11 @@ def _parse_output(content: str) -> list[lsp.Diagnostic]:
                 result["properties"]["issue_severity"],
                 result["properties"]["issue_confidence"],
             ),
-            code=location["region"]["snippet"]["text"],
-            source=TOOL_MODULE,
+            code=f"{result["ruleId"]}:{rule["name"]}",
+            code_description=lsp.CodeDescription(
+                href=rule["helpUri"],
+            ),
+            source=TOOL_DISPLAY,
         )
         diagnostics.append(diagnostic)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bandit-pycqa",
-    "version": "2025.3.0",
+    "version": "2025.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bandit-pycqa",
-            "version": "2025.3.0",
+            "version": "2025.3.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bandit-pycqa",
     "displayName": "Bandit by PyCQA",
     "description": "The official Bandit extension developed by PyCQA",
-    "version": "2025.3.1",
+    "version": "2025.3.2",
     "preview": true,
     "serverInfo": {
         "name": "Bandit",

--- a/src/test/python_tests/requirements.txt
+++ b/src/test/python_tests/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes ./src/test/python_tests/requirements.in
 #
-iniconfig==2.0.0 \
-    --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
-    --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+iniconfig==2.1.0 \
+    --hash=sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7 \
+    --hash=sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760
     # via pytest
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \


### PR DESCRIPTION
The code attribute should actually be the bandit test id and name, not source code. Plus the code description is a link to the docs.

Also bumped the version