### PR TITLE
Add colorama as a needed requirement

### DIFF
--- a/src/test/python_tests/requirements.in
+++ b/src/test/python_tests/requirements.in
@@ -12,3 +12,4 @@
 pytest
 PyHamcrest
 python-jsonrpc-server
+colorama


### PR DESCRIPTION
Bandit has a dependency on colorama, but only on windows. However, vscode template generates a requirements.txt based for all operating systems. 

So this fix, always adds colorama.