### PR TITLE
Add bandit team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @ericwb @lukehinds @sigmavirus24


### PR DESCRIPTION
Add the same bandit maintainers to the code owners for this project.