### PR TITLE
Use tag enhancement for Enhancements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,7 +6,7 @@ changelog:
   categories:
     - title: Enhancements
       labels:
-        - 'feature-request'
+        - 'enhancement'
 
     - title: Bug Fixes
       labels:


### PR DESCRIPTION
The release yaml guides how the release notes are generated. It will separate bugs from features based on a PR tag.

This fix switches to use the default tag of enhancment rather than feature-request.