### PR TITLE
Apply ini syntax for a .bandit file

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
         "vsce-package": "vsce package -o bandit.vsix"
     },
     "contributes": {
+        "languages": [
+            {
+                "filenames": [
+                    ".bandit"
+                ],
+                "id": "ini"
+            }
+        ],
         "configuration": {
             "properties": {
                 "bandit.args": {


### PR DESCRIPTION
Bandit understands a .bandit file for some CLI config options.  This change informs VSCode that any .bandit file should be treated as an ini file, thus applying syntax highlighting and such.