### PR TITLE
Add basic issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Ask a question
+    url: https://github.com/PyCQA/vscode-bandit/discussions
+    about: Please post questions in discussions.


### PR DESCRIPTION
Add link to discussions for users with questions rather than using issues to track.

This change also disables blank issues.