### PR TITLE
Remove Preview label

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Bandit by PyCQA",
     "description": "%extension.description%",
     "version": "2025.14.0",
-    "preview": true,
+    "preview": false,
     "serverInfo": {
         "name": "Bandit",
         "module": "bandit"


### PR DESCRIPTION
The extension works fairly well so at this point don't think there is a need to continue with a Preview label.